### PR TITLE
Handle 0-value date as null on formatters

### DIFF
--- a/format_test.go
+++ b/format_test.go
@@ -1,6 +1,9 @@
 package godate
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestParse(t *testing.T) {
 	d, err := Parse(RFC3339, "2017-10-20")
@@ -35,8 +38,8 @@ func TestDate_Format(t *testing.T) {
 	}
 
 	d = Date{}
-	if d.Format(RFC3339) != "0001-01-01" {
-		t.Errorf("expected zero date is formatted godate.RFC3339, but got %s", d.Format(RFC3339))
+	if d.Format(RFC3339) != "" {
+		t.Errorf("expected zero date is formatted as empty, but got %s", d.Format(RFC3339))
 	}
 }
 
@@ -47,7 +50,78 @@ func TestDate_String(t *testing.T) {
 	}
 
 	d = Date{}
-	if d.Format(RFC3339) != "0001-01-01" {
-		t.Errorf("expected zero date is formatted godate.RFC3339, but got %s", d.Format(RFC3339))
+	if d.Format(RFC3339) != "" {
+		t.Errorf("expected zero date is formatted as empty, but got %s", d.Format(RFC3339))
+	}
+}
+
+func TestDate_MarshalJSON(t *testing.T) {
+	d := New(2017, 10, 27)
+	if buf, err := d.MarshalJSON(); err != nil {
+		t.Errorf("expected to be marshaled, but got error %v", err)
+	} else if string(buf) != "\"2017-10-27\"" {
+		t.Errorf("expected formatted json string, but got %s", buf)
+	}
+
+	d = Date{}
+	if buf, err := d.MarshalJSON(); err != nil {
+		t.Errorf("expected to be marshaled, but got error %v", err)
+	} else if string(buf) != "null" {
+		t.Errorf("expected formatted json string, but got %s", buf)
+	}
+}
+
+func TestDate_UnmarshalJSON(t *testing.T) {
+	d := Date{}
+	if err := d.UnmarshalJSON([]byte("\"2017-10-27\"")); err != nil {
+		t.Errorf("expected to be unmarshaled, but got error %v", err)
+	} else if d != New(2017, 10, 27) {
+		t.Errorf("expected parsed date, but got %s", d)
+	}
+
+	d = New(2017, 10, 28)
+	if err := d.UnmarshalJSON([]byte("null")); err != nil {
+		t.Errorf("expected to be unmarshaled, but got error %v", err)
+	} else if !d.IsZero() {
+		t.Errorf("expected 0-value date, but got %s", d)
+	}
+}
+
+func TestDate_Value(t *testing.T) {
+	d := New(2017, 10, 27)
+	if v, err := d.Value(); err != nil {
+		t.Errorf("expected to get sql value, but got error %v", err)
+	} else if v != "2017-10-27" {
+		t.Errorf("expected formatted string, but got %s", v)
+	}
+
+	d = Date{}
+	if v, err := d.Value(); err != nil {
+		t.Errorf("expected to get sql value, but got error %v", err)
+	} else if v != nil {
+		t.Errorf("expected nil, but got %s", v)
+	}
+}
+
+func TestDate_Scan(t *testing.T) {
+	d := Date{}
+	if err := d.Scan("2017-10-27"); err != nil {
+		t.Errorf("expected to be scanned, but got error %v", err)
+	} else if d != New(2017, 10, 27) {
+		t.Errorf("expected parsed date, but got %s", d)
+	}
+
+	d = Date{}
+	if err := d.Scan(time.Date(2017, time.October, 27, 0, 0, 0, 0, time.UTC)); err != nil {
+		t.Errorf("expected to be scanned, but got error %v", err)
+	} else if d != New(2017, 10, 27) {
+		t.Errorf("expected parsed date, but got %s", d)
+	}
+
+	d = New(2017, 10, 28)
+	if err := d.Scan(nil); err != nil {
+		t.Errorf("expected to be scanned, but got error %v", err)
+	} else if !d.IsZero() {
+		t.Errorf("expected 0-value date, but got %s", d)
 	}
 }


### PR DESCRIPTION
Format a 0-value date as empty.
Marshal/unmarshal a 0-value date as null for JSON.
Convert  a 0-value date as null for SQL.

https://github.com/sunmyinf/godate/issues/35
