### PR TITLE
Handle specific timezone into the UTC

### DIFF
--- a/date.go
+++ b/date.go
@@ -76,8 +76,10 @@ const secondsPerDay int64 = 60 * 60 * 24
 
 var zeroUnix = time.Time{}.Unix()
 
+// Handle time as UTC in godate
 func toElapsedDays(t time.Time) ElapsedDays {
-	elapsedSecs := t.Unix() - zeroUnix
+	_, offset := t.Zone()
+	elapsedSecs := (t.Unix() + int64(offset)) - zeroUnix
 	return ElapsedDays(elapsedSecs / secondsPerDay)
 }
 

--- a/date_test.go
+++ b/date_test.go
@@ -30,10 +30,12 @@ func TestNew(t *testing.T) {
 func TestNewFromTime(t *testing.T) {
 	now := time.Now()
 	zeroTime := time.Time{}
+	asiaTokyo, _ := time.LoadLocation("Asia/Tokyo")
 
 	times := []time.Time{
 		now,
 		time.Date(1969, 12, 1, 0, 0, 1, 0, time.UTC),
+		time.Date(1969, 12, 1, 0, 0, 1, 0, asiaTokyo),
 		zeroTime,
 	}
 


### PR DESCRIPTION
Japanese below.

## Purpose of this PR
To handle date with timezone correctly, revised calculation in `toElapsedDays`, calculating `time.Time` instance having Location except for UTC into UTC.
And add test for this revision.

## Background
Now, Godate cannot handle correctly `time.Time` instance having location except for UTC, because I don't know returned value of `Unix()` is influenced from Location.

For example, when database has timezone settings as JST and `2018-04-30` date typed column and scan the date data, `Date.Scan()` scans `time.Time` instance of `2018-04-30T00:00:00` with JST Location. Then value of `String()` of the `Date` instance returns `2018-04-29` (expected `2018-04-30`).
```go
package main

import (
	"fmt"
	"time"
)

func main() {
	asiaTokyo, _ := time.LoadLocation("Asia/Tokyo")
	dTokyo := time.Date(1969, 12, 1, 0, 0, 0, 0, asiaTokyo)
	dUTC := time.Date(1969, 12, 1, 0, 0, 0, 0, time.UTC)

	fmt.Println(dTokyo.Unix(), dUTC.Unix())
	fmt.Println(dTokyo.Unix() - dUTC.Unix())
}
```
```
$ go run test.go
-2710800 -2678400
-32400
```

The reason the `Date` instance returns wrong date is that `time.Time` instance passed to `NewFromTime` method has `Asia/Tokyo` locatio, and the instance's `Unix()` method returns value substracted `-09:00` (-32400unixsec) from expected secs.

--------------------------
## やったこと
`toElapsedDays` 内部で一律UTCに変換して `ElapsedDays` を計算するようにした。
`Time` インスタンスの `In` メソッドは、持ってる時刻の情報は変換せず、出力を指定されたLocationに移すだけなのでここでは使わない。

## 背景
UTC以外のLocation情報を持った `Time` インスタンスの `Unix`メソッドは、そのLocationのUTCとの時差分が計算された値を返す。

DBにTimezoneの設定がされていると、`Scan`メソッドにそのDBのTimezone情報を含めた `Time` インスタンスが渡されるため、その設定がもしJSTだった場合必ず `09:00` (32400unix秒)だけ引かれてしまうので想定した日付の1日前の値が返ってくるということがわかった。

渡ってきた日付のまま扱いたいので、時差分を計算してUTCに戻した上でElapsedDaysに変換することで正しく扱えるようにする。